### PR TITLE
Packaging Electron for Windows and Linux (npm run package:all)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -70,9 +70,20 @@ Example: `./parity --chain=classic --rpccorsdomain=*` allow requests from any do
 
 ## Package
 
+For current OS:
+
 ```bash
 $ npm run package
 ```
+
+For Windows and Linux:
+
+```bash
+$ npm run package:all
+```
+
+Note: Packaging for Windows platform on Linux needs Wine to be installed.
+
 
 # License
 

--- a/electron/package.js
+++ b/electron/package.js
@@ -5,6 +5,7 @@ const webpack = require('webpack');
 const webpackConfig = require('./webpack.electron.js');
 
 const appName = pkg.productName;
+const argv = require('minimist')(process.argv.slice(2));
 
 /**
  * Configuration for electron-packager
@@ -12,8 +13,6 @@ const appName = pkg.productName;
 const packOpts = {
   dir: './',
   name: appName,
-  platform: os.platform(),
-  arch: os.arch(),
   overwrite: true, // overwrite release folder
   ignore: [
     '^/release($|/)',
@@ -29,14 +28,19 @@ webpack(webpackConfig, (err, stats) => {
     return;
   }
 
-  // Run electron-packager
-  pack();
+  const platforms = (argv.all ? ['linux', 'win32'] : [os.platform()]);
+  // Run electron-packager for each platform
+  platforms.forEach(function(platform) {
+    pack(platform, os.arch());
+  })
 });
 
 
-function pack() {
-  console.log("Start packaging...")
+function pack(platform, arch) {
+  console.log(`Start packaging for ${platform}`)
   const opts = Object.assign({}, packOpts, {
+    platform: platform,
+    arch: arch,
     out: `release`
   });
 
@@ -44,6 +48,8 @@ function pack() {
 }
 
 function onPackFinished(err, appPaths) {
-  if (err) return console.error(err);
-  console.log("Finished")
+  if (err) {
+    return console.error(err);
+  }
+  console.log(`Finished ${appPaths}`)
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test:watch": "node ./node_modules/karma/bin/karma start",
     "test": "npm run build && node ./node_modules/karma/bin/karma start --single-run",
     "lint": "./node_modules/eslint/bin/eslint.js ./src/",
-    "package": "npm run build && NODE_ENV=production node electron/package.js"
+    "package": "npm run build && NODE_ENV=production node electron/package.js",
+    "package:all": "npm run package -- --all"
   },
   "keywords": [
     "react",
@@ -93,6 +94,7 @@
     "karma-phantomjs-launcher": "^1.0.2",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.7.0",
+    "minimist": "^1.2.0",
     "node-sass": "4.5.2",
     "phantomjs-prebuilt": "^2.1.14",
     "recursive-readdir-sync": "^1.0.6",

--- a/src/store/tokenActions.js
+++ b/src/store/tokenActions.js
@@ -1,4 +1,4 @@
-import { rpc } from 'lib/rpcapi';
+import { rpc } from '../lib/rpc';
 import { parseString, padLeft, getNakedAddress, fromTokens } from 'lib/convert';
 
 /** TODO #30: Convert ABI Function name to Function Signature **/


### PR DESCRIPTION
- `npm run package:all` command builds electron packages for linux and win32 platforms
- README has been updated