### PR TITLE
eslint syntax, fix `getFiat`, and isaac's happier settings for development

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,7 +32,10 @@
     "no-unused-vars": ["warn", {
       "argsIgnorePattern": "(dispatch|state|ownProps|reset|handleSubmit|resetForm|submitting|reject|resolve)"
     }],
-    "no-plusplus": 0
+    "no-plusplus": 0,
+    "object-curly-spacing": 0,
+    "object-shorthand": 1,
+    "no-console": 0
   },
   "plugins": [
     "react"

--- a/README.adoc
+++ b/README.adoc
@@ -49,11 +49,16 @@ npm test
 ```
 
 ## Rebuild and start server
+This will automatically watch for changes and inject live-updating builds on your local server.
 ```
 npm run start
 ```
-
-Open `http://localhost:8000` with your browser.
+Ensure you have both __geth__ and __emerald-rs__ running:
+```
+geth --rpc # will open port on localhost:8545 by default
+cd path/to/emerald-rs; RUST_LOG=emerald,rpc cargo run # will connect on default geth port (8545), then open it's own port for the wallet on localhost:1920
+```
+Finally, open `http://localhost:8000` with your browser.
 
 ## Run node
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "version": "0.1.0",
   "description": "Emerald - Ethereum Classic Wallet",
   "main": "./build/main.js",
+  "moduleRoots": [ "src/lib" ],
   "scripts": {
     "build": "node build --no-watch",
     "build:watch": "node build",

--- a/src/components/accounts/list.js
+++ b/src/components/accounts/list.js
@@ -12,7 +12,7 @@ import { translate } from 'react-i18next';
 import { gotoScreen } from 'store/screenActions';
 import Account from './account';
 
-const Render = translate("accounts")(({ t, accounts, createAccount }) => {
+const Render = translate('accounts')(({ t, accounts, createAccount }) => {
     const table = <Table selectable={false}>
         <TableHeader displaySelectAll={false} adjustForCheckbox={false}>
             <TableRow>
@@ -35,9 +35,9 @@ const Render = translate("accounts")(({ t, accounts, createAccount }) => {
         <div id="accounts-list">
             <Card style={cardSpace}>
                 <CardHeader
-                    title={t("list.title")}
+                    title={t('list.title')}
                     titleStyle={titleStyle}
-                    subtitle={t("list.subtitle")}
+                    subtitle={t('list.subtitle')}
                     avatar={titleAvatar}
                     actAsExpander={false}
                     showExpandableButton={false}
@@ -46,7 +46,7 @@ const Render = translate("accounts")(({ t, accounts, createAccount }) => {
                     {table}
                 </CardText>
                 <CardActions>
-                    <FlatButton label={t("list.create")}
+                    <FlatButton label={t('list.create')}
                                 onClick={createAccount}
                                 icon={<FontIcon className="fa fa-plus-circle" />}/>
                 </CardActions>

--- a/src/components/accounts/show.js
+++ b/src/components/accounts/show.js
@@ -23,19 +23,19 @@ TokenRow.propTypes = {
     token: PropTypes.object.isRequired,
 };
 
-const Render = translate("accounts")(({ t, account, fiat, createTx }) => {
-    const value = t("show.value", {value: account.get('balance') ? account.get('balance').getEther() : '?'});
+const Render = translate('accounts')(({ t, account, fiat, createTx }) => {
+    const value = t('show.value', {value: account.get('balance') ? account.get('balance').getEther() : '?'});
 
     return (
         <Card style={cardSpace}>
             <CardHeader
-                title={t("show.header", {account: account.get('name') || account.get('id')})}
+                title={t('show.header', {account: account.get('name') || account.get('id')})}
                 subtitle={value}
                 actAsExpander={true}
                 showExpandableButton={true}
             />
             <CardActions>
-                <FlatButton label={t("show.send")}
+                <FlatButton label={t('show.send')}
                             onClick={createTx}
                             icon={<FontIcon className="fa fa-arrow-circle-o-right" />}/>
             </CardActions>
@@ -44,20 +44,20 @@ const Render = translate("accounts")(({ t, account, fiat, createTx }) => {
                     <Col xs={8}>
                         <DescriptionList>
                             {account.get('description') && <div>
-                            <DescriptionTitle>{t("show.description.title")}</DescriptionTitle>
+                            <DescriptionTitle>{t('show.description.title')}</DescriptionTitle>
                             <DescriptionData>{account.get('description')}</DescriptionData>
                             </div>}
 
-                            <DescriptionTitle>{t("show.description.address")}</DescriptionTitle>
+                            <DescriptionTitle>{t('show.description.address')}</DescriptionTitle>
                             <DescriptionData>{account.get('id')}</DescriptionData>
 
-                            <DescriptionTitle>{t("show.description.sentTransactions")}</DescriptionTitle>
+                            <DescriptionTitle>{t('show.description.sentTransactions')}</DescriptionTitle>
                             <DescriptionData>{account.get('txcount') || '0'}</DescriptionData>
 
-                            <DescriptionTitle>{t("show.description.etherBalance")}</DescriptionTitle>
+                            <DescriptionTitle>{t('show.description.etherBalance')}</DescriptionTitle>
                             <DescriptionData>{value}</DescriptionData>
 
-                            <DescriptionTitle>{t("show.description.tokenBalance")}</DescriptionTitle>
+                            <DescriptionTitle>{t('show.description.tokenBalance')}</DescriptionTitle>
                             <DescriptionData>
                                 {account
                                     .get('tokens')

--- a/src/components/tx/list.js
+++ b/src/components/tx/list.js
@@ -19,7 +19,7 @@ const Render = ({ transactions }) => {
         titleStyle: {
             fontSize: '20px',
         },
-    };                 
+    };
 
     const table = <Table selectable={false}>
         <TableHeader displaySelectAll={false} adjustForCheckbox={false}>
@@ -35,6 +35,7 @@ const Render = ({ transactions }) => {
             {transactions.map((tx) => <Transaction key={tx.get('hash')} tx={tx}/>)}
         </TableBody>
     </Table>;
+
     const titleAvatar = <Avatar icon={<FontIcon className="fa fa-dot-circle-o fa-2x" />} />;
 
     return (

--- a/src/components/tx/list.js
+++ b/src/components/tx/list.js
@@ -58,7 +58,7 @@ const Render = ({ transactions }) => {
 
 Render.propTypes = {
     transactions: PropTypes.array.isRequired,
-}
+};
 
 const TransactionsList = connect(
     (state, ownProps) => {

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -20,7 +20,7 @@ export class Wei extends Immutable.Record({ val: ZERO }) {
             });
         } else {
             super({
-                val: val,
+                val,
             });
         }
     }

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -34,6 +34,9 @@ export class Wei extends Immutable.Record({ val: ZERO }) {
         return new Wei(this.val.plus(another.val));
     }
     getFiat(r) {
+        if (typeof (r) === 'undefined' || r === null) {
+            r = 0;
+        }
         const rate = new BigNumber(r.toString());
         return this.val.dividedBy(ETHER).mul(rate).toFixed(5);
     }

--- a/src/store/networkActions.js
+++ b/src/store/networkActions.js
@@ -1,3 +1,4 @@
+import log from 'loglevel';
 import { rpc } from '../lib/rpc';
 import { start } from '../store/store';
 
@@ -57,7 +58,7 @@ export function loadSyncing() {
 export function switchChain(network, id) {
     return (dispatch) =>
         rpc.call('backend_switchChain', [network]).then((result) => {
-            console.debug('switch chain', result);
+            log.debug('switch chain', result);
             dispatch({
                 type: 'NETWORK/SWITCH_CHAIN',
                 network,

--- a/src/store/networkActions.js
+++ b/src/store/networkActions.js
@@ -1,11 +1,8 @@
 import log from 'loglevel';
 import { rpc } from '../lib/rpc';
-import { start } from '../store/store';
+import { start, rates } from '../store/store';
 
 let watchingHeight = false;
-//  (whilei: development: loading so often slows things a lot for me and clutters logs)
-const loadSyncRate = 60 * 1000; // milliseconds
-const loadHeightRate = 5 * 60 * 1000; // ditto
 
 export function loadHeight(watch) {
     return (dispatch) =>
@@ -16,7 +13,7 @@ export function loadHeight(watch) {
             });
             if (watch && !watchingHeight) {
                 watchingHeight = true;
-                setTimeout(() => dispatch(loadHeight(true)), loadHeightRate);
+                setTimeout(() => dispatch(loadHeight(true)), rates.loadHeightRate);
             }
         });
 }
@@ -44,13 +41,13 @@ export function loadSyncing() {
                     syncing: true,
                     status: result,
                 });
-                setTimeout(() => dispatch(loadSyncing()), loadSyncRate);
+                setTimeout(() => dispatch(loadSyncing()), rates.loadSyncRate);
             } else {
                 dispatch({
                     type: 'NETWORK/SYNCING',
                     syncing: false,
                 });
-                setTimeout(() => dispatch(loadHeight(true)), loadSyncRate);
+                setTimeout(() => dispatch(loadHeight(true)), rates.loadSyncRate);
             }
         });
 }

--- a/src/store/networkActions.js
+++ b/src/store/networkActions.js
@@ -1,5 +1,6 @@
 import { rpc } from '../lib/rpc';
-import { start } from 'store/store'
+import { start } from '../store/store';
+
 
 let watchingHeight = false;
 

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -17,6 +17,17 @@ import contractReducers from './contractReducers';
 import networkReducers from './networkReducers';
 import screenReducers from './screenReducers';
 
+export const rates = {
+    // (whilei: development: loading so often slows things a lot for me and clutters logs)
+    // all rates in milliseconds
+    loadSyncRate: 60 * 1000, // prod: 1000
+    loadSyncCheckRate: 3 * 60 * 1000, // prod: 3000
+    loadSyncDoublecheckRate: 15 * 60 * 1000, // prod: 30 * 1000
+    loadHeightRate: 5 * 60 * 1000, // prod: 5000
+    getExchangeRatesRate: 900000,
+    refreshAllTxRate: 20 * 2000, // prod: 2000
+};
+
 const stateTransformer = (state) => ({
     accounts: state.accounts.toJS(),
     addressBook: state.addressBook.toJS(),
@@ -51,7 +62,7 @@ export const store = createStore(
 
 function refreshAll() {
     store.dispatch(refreshTrackedTransactions());
-    setTimeout(refreshAll, 2000);
+    setTimeout(refreshAll, rates.refreshAllTxRate);
 }
 
 export function start() {
@@ -62,8 +73,10 @@ export function start() {
     store.dispatch(loadContractList());
     store.dispatch(gotoScreen('home'));
     store.dispatch(loadHeight());
-    setTimeout(() => store.dispatch(getExchangeRates()), 900000);
-    setTimeout(() => store.dispatch(loadSyncing()), 3000); // check for syncing
-    setTimeout(() => store.dispatch(loadSyncing()), 30000); // double check for syncing after 30 seconds
+    setTimeout(() => store.dispatch(getExchangeRates()), rates.getExchangeRatesRate);
+    // check for syncing
+    setTimeout(() => store.dispatch(loadSyncing()), rates.loadSyncCheckRate);
+    // double check for syncing after 30 seconds
+    setTimeout(() => store.dispatch(loadSyncing()), rates.loadSyncDoublecheckRate);
     setTimeout(refreshAll, 5000);
 }

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -20,6 +20,8 @@ import screenReducers from './screenReducers';
 const second = 1000;
 const minute = 60 * second;
 export const intervalRates = {
+    second, // (whilei) this must be the newfangled object-shorthand...?
+    minute,
     // (whilei: development: loading so often slows things a lot for me and clutters logs; that's why I have
     // stand-in times here for development)
     // Continue is repeating timeouts.


### PR DESCRIPTION
- Updates `.eslintrc` to accommodate some warnings I was getting
- Updates a couple of files  -- only as I came across them (far from complete) -- to use those eslinter settings
  + `single-quotes`,
  + `object-shorthand`,
  + `object-curly-spacing`...
I'm not set on these settings; if you have other preferences I'm happy to adjust to whatever works. I would just like to make the code (eventually) compatible with the linter in any case.

- Updates `store/networkActions.js` to use a much slower polling interval for sync status. 1/second was drowning my computer. This patch is not ideal -- it should eventually _not_ be hardcoded, instead it should be configured as a node flag or something else -- but I haven't figured out how to do that yet. I'm not set on this; will be happy to revert if I'm the only one affected; I can just keep a git stash of the change if I need to.
- Fix `getFiat` function to check for undefined/null argument, in which case it assumes `0`
- Minor addition to README to cover a basic geth-connector-wallet setup.
