### PR TITLE
Elaine/keyimport

### DIFF
--- a/src/components/accounts/add/importjson.js
+++ b/src/components/accounts/add/importjson.js
@@ -45,7 +45,6 @@ class ImportRender extends React.Component {
         const { submitSucceeded, invalid, pristine, submitting, cancel } = this.props;
 
         const p = this.state.accountId && accounts.findKey((acc) => acc.get('id') === this.state.accountId);
-        console.log(p)
         const account = p && (p >= 0) && accounts.get(p);
 
         return (

--- a/src/components/accounts/add/importjson.js
+++ b/src/components/accounts/add/importjson.js
@@ -16,6 +16,9 @@ import { required } from 'lib/validators';
 import { translate } from 'react-i18next';
 import AccountShow from '../show';
 
+import { green300, red300 } from 'material-ui/styles/colors';
+
+
 class ImportRender extends React.Component {
     constructor(props) {
         super(props);
@@ -28,6 +31,7 @@ class ImportRender extends React.Component {
 
     submitFile() {
         this.props.handleSubmit().then((result) => {
+            console.log(result)
             if (result.error) {
                 this.setState({ fileError: result.error.toString() });
             } else {
@@ -40,7 +44,8 @@ class ImportRender extends React.Component {
         const { t, accounts } = this.props;
         const { submitSucceeded, invalid, pristine, submitting, cancel } = this.props;
 
-        const p = this.state.accountId && accounts.findKey(this.state.accountId);
+        const p = this.state.accountId && accounts.findKey((acc) => acc.get('id') === this.state.accountId);
+        console.log(p)
         const account = p && (p >= 0) && accounts.get(p);
 
         return (
@@ -69,6 +74,9 @@ class ImportRender extends React.Component {
                                     disabled={pristine || submitting || invalid } />
                     </form>
                 </CardText>
+                {account && <CardText color={green100}>
+                    Account Successfully Imported.
+                </CardText>}
                 {account && <CardText>
                      <AccountShow key={(account === undefined) ? undefined : account.get('id')} account={account}/>
                      <FlatButton label={t("common:done")}
@@ -76,7 +84,7 @@ class ImportRender extends React.Component {
                                 icon={<FontIcon className="fa fa-home" />}/>
                 </CardText>}
                 {this.state.fileError}
-                {this.state.fileError && <CardText>
+                {this.state.fileError && <CardText color={red300}>
                     {this.state.fileError}
                 </CardText>}
                 <CardActions>
@@ -91,6 +99,7 @@ class ImportRender extends React.Component {
 
 ImportRender.propTypes = {
     account: PropTypes.object.isRequired,
+    accounts: PropTypes.array.isRequired,
     submitSucceeded: PropTypes.bool.isRequired,
     handleSubmit: PropTypes.func.isRequired,
     invalid: PropTypes.bool.isRequired,

--- a/src/components/accounts/add/importjson.js
+++ b/src/components/accounts/add/importjson.js
@@ -31,7 +31,6 @@ class ImportRender extends React.Component {
 
     submitFile() {
         this.props.handleSubmit().then((result) => {
-            console.log(result)
             if (result.error) {
                 this.setState({ fileError: result.error.toString() });
             } else {

--- a/src/components/accounts/edit.js
+++ b/src/components/accounts/edit.js
@@ -1,0 +1,23 @@
+import { connect } from 'react-redux';
+import { AddressForm } from '../addressbook/form';
+
+const AccountEdit = connect(
+    (state, ownProps) => ({
+        blockAddress: true,
+        initialValues: {
+            name: ownProps.address.get('name'),
+            address: ownProps.address.get('id'),
+            description: ownProps.address.get('description'),
+        },
+    }),
+    (dispatch, ownProps) => ({
+        onSubmit: (data) => {
+            ownProps.submit(data);
+        },
+        cancel: () => {
+            ownProps.cancel();
+        },
+    })
+)(AddressForm);
+
+export default AccountEdit;

--- a/src/components/accounts/show.js
+++ b/src/components/accounts/show.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Card, CardActions, CardText } from 'material-ui/Card';
 import { AddressAvatar } from 'elements/dl';
+import Dialog from 'material-ui/Dialog';
 import FlatButton from 'material-ui/FlatButton';
 import FontIcon from 'material-ui/FontIcon';
 import { Row, Col } from 'react-flexbox-grid/lib/index';
@@ -23,15 +24,45 @@ TokenRow.propTypes = {
     token: PropTypes.object.isRequired,
 };
 
-const Render = translate('accounts')(({ t, account, rates, editAccount, createTx, showModal }) => {
-    const value = t('show.value', {value: account.get('balance') ? account.get('balance').getEther() : '?'});
-    const pending = account.get('balancePending') ? `(${account.get('balancePending').getEther()} pending)` : null;
+class AccountRender extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            edit: false,
+            showModal: false,
+        };
+    }
 
-    return (
+    handleEdit = () => {
+        this.setState({ edit: true });
+    }
+
+    handleSave = () => {
+        this.setState({ edit: false });
+    }
+
+    showModal = () => {
+        this.setState({ showModal: true });
+    }
+
+    closeModal = () => {
+        this.setState({ showModal: false });
+    }
+
+    render() {
+        const { account, rates, createTx, goBack } = this.props;
+        const value = account.get('balance') ? account.get('balance').getEther() : '?';
+        const pending = account.get('balancePending') ? `(${account.get('balancePending').getEther()} pending)` : null;
+
+
+        return (
         <Card style={cardSpace}>
-            <CardText>
-            Dashboard button
-            </CardText>
+            <CardActions>
+                <FlatButton label="DASHBOARD"
+                            primary={true}
+                            onClick={goBack}
+                            icon={<FontIcon className="fa fa-arrow-left" />}/>
+            </CardActions>
             <CardText>
                 <Row>
                     <Col xs={8}>
@@ -45,7 +76,7 @@ const Render = translate('accounts')(({ t, account, rates, editAccount, createTx
                             secondary={account.get('id')}
                             tertiary={account.get('description')}
                             primary={account.get('name')}
-                            onClick={editAccount}
+                            onClick={this.handleEdit}
                         />
                     </Col>
                     <Col xs={4} md={2} mdOffset={2}>
@@ -55,21 +86,30 @@ const Render = translate('accounts')(({ t, account, rates, editAccount, createTx
             </CardText>
             <CardActions>
                 <FlatButton label="ADD ETHER"
-                            onClick={showModal}
+                            onClick={this.showModal}
                             icon={<FontIcon className="fa fa-qrcode" />}/>
-                <FlatButton label={t('show.send')}
+                <FlatButton label="SEND"
                             onClick={createTx}
                             icon={<FontIcon className="fa fa-arrow-circle-o-right" />}/>
             </CardActions>
-
+            {/*
+                TODO: Replace with @whilei's ADD ETHER modal
+            */}
+            <Dialog
+              title="ADD ETHER!!"
+              modal={false}
+              open={this.state.showModal}
+              onRequestClose={this.closeModal}
+            />
         </Card>
-    );
-});
+        );
+    }
+}
 
-Render.propTypes = {
+AccountRender.propTypes = {
     account: PropTypes.object.isRequired,
     createTx: PropTypes.func.isRequired,
-    editAccount: PropTypes.func.isRequired,
+    goBack: PropTypes.func.isRequired,
 };
 
 const AccountShow = connect(
@@ -96,10 +136,13 @@ const AccountShow = connect(
             log.debug('create tx from', account.get('id'));
             dispatch(gotoScreen('create-tx', account));
         },
+        goBack: () => {
+            dispatch(gotoScreen('home'));
+        },
         editAccount: () => {
 
         }
     })
-)(Render);
+)(AccountRender);
 
 export default AccountShow;

--- a/src/components/accounts/show.js
+++ b/src/components/accounts/show.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Card, CardActions, CardHeader, CardText } from 'material-ui/Card';
+import { Card, CardActions, CardText } from 'material-ui/Card';
+import { AddressAvatar } from 'elements/dl';
 import FlatButton from 'material-ui/FlatButton';
 import FontIcon from 'material-ui/FontIcon';
 import { Row, Col } from 'react-flexbox-grid/lib/index';
-import { DescriptionList, DescriptionTitle, DescriptionData } from 'elements/dl';
 import QRCode from 'qrcode.react';
 import log from 'loglevel';
 import { translate } from 'react-i18next';
@@ -23,66 +23,45 @@ TokenRow.propTypes = {
     token: PropTypes.object.isRequired,
 };
 
-const Render = translate('accounts')(({ t, account, fiat, createTx }) => {
+const Render = translate('accounts')(({ t, account, rates, editAccount, createTx, showModal }) => {
     const value = t('show.value', {value: account.get('balance') ? account.get('balance').getEther() : '?'});
     const pending = account.get('balancePending') ? `(${account.get('balancePending').getEther()} pending)` : null;
 
     return (
         <Card style={cardSpace}>
-            <CardHeader
-                title={t('show.header', {account: account.get('name') || account.get('id')})}
-                subtitle={value}
-                actAsExpander={true}
-                showExpandableButton={true}
-            />
-            <CardActions>
-                <FlatButton label={t('show.send')}
-                            onClick={createTx}
-                            icon={<FontIcon className="fa fa-arrow-circle-o-right" />}/>
-            </CardActions>
-            <CardText expandable={true}>
+            <CardText>
+            Dashboard button
+            </CardText>
+            <CardText>
                 <Row>
                     <Col xs={8}>
-                        <DescriptionList>
-                            {account.get('description') && <div>
-                            <DescriptionTitle>{t('show.description.title')}</DescriptionTitle>
-                            <DescriptionData>{account.get('description')}</DescriptionData>
-                            </div>}
+                        <h2>
+                            {value}
+                            {pending && <FlatButton label={`${pending} pending`} primary={true} />}
+                        </h2>
+                        {account.get('balance') ? `$${account.get('balance').getFiat(rates.get('usd'))}` : ''}
 
-                            <DescriptionTitle>{t('show.description.address')}</DescriptionTitle>
-                            <DescriptionData>{account.get('id')}</DescriptionData>
-
-                            <DescriptionTitle>{t('show.description.sentTransactions')}</DescriptionTitle>
-                            <DescriptionData>{account.get('txcount') || '0'}</DescriptionData>
-
-                            <DescriptionTitle>{t('show.description.etherBalance')}</DescriptionTitle>
-                            <DescriptionData>{value}</DescriptionData>
-                            <DescriptionData>{value} {pending}</DescriptionData>
-
-                            <DescriptionTitle>{t('show.description.tokenBalance')}</DescriptionTitle>
-                            <DescriptionData>
-                                {account
-                                    .get('tokens')
-                                    .map((tok) =>
-                                        <TokenRow token={tok} key={tok.get('address')}/>
-                                )}
-                            </DescriptionData>
-
-                            <DescriptionTitle>Equivalent Values</DescriptionTitle>
-                            <DescriptionData>
-                                <div><span>BTC {fiat.btc}</span></div>
-                                <div><span>USD {fiat.usd}</span></div>
-                                <div><span>CNY {fiat.cny}</span></div>
-                            </DescriptionData>
-
-
-                        </DescriptionList>
+                        <AddressAvatar
+                            secondary={account.get('id')}
+                            tertiary={account.get('description')}
+                            primary={account.get('name')}
+                            onClick={editAccount}
+                        />
                     </Col>
                     <Col xs={4} md={2} mdOffset={2}>
                         <QRCode value={account.get('id')} />
                     </Col>
                 </Row>
             </CardText>
+            <CardActions>
+                <FlatButton label="ADD ETHER"
+                            onClick={showModal}
+                            icon={<FontIcon className="fa fa-qrcode" />}/>
+                <FlatButton label={t('show.send')}
+                            onClick={createTx}
+                            icon={<FontIcon className="fa fa-arrow-circle-o-right" />}/>
+            </CardActions>
+
         </Card>
     );
 });
@@ -90,6 +69,7 @@ const Render = translate('accounts')(({ t, account, fiat, createTx }) => {
 Render.propTypes = {
     account: PropTypes.object.isRequired,
     createTx: PropTypes.func.isRequired,
+    editAccount: PropTypes.func.isRequired,
 };
 
 const AccountShow = connect(
@@ -107,6 +87,7 @@ const AccountShow = connect(
         }
         return {
             fiat,
+            rates,
         };
     },
     (dispatch, ownProps) => ({
@@ -115,6 +96,9 @@ const AccountShow = connect(
             log.debug('create tx from', account.get('id'));
             dispatch(gotoScreen('create-tx', account));
         },
+        editAccount: () => {
+
+        }
     })
 )(Render);
 

--- a/src/store/accountActions.js
+++ b/src/store/accountActions.js
@@ -141,6 +141,7 @@ export function importWallet(wallet, name, description) {
                             name,
                             description,
                         });
+                        dispatch(loadAccountBalance(result));
                         resolve(result);
                     } else {
                         reject({error: result});

--- a/src/store/accountActions.js
+++ b/src/store/accountActions.js
@@ -74,6 +74,22 @@ export function createAccount(password, name, description) {
         });
 }
 
+export function updateAccount(address, name, description) {
+    return (dispatch) =>
+        rpc.call('emerald_updateAccounts', [{
+            name,
+            description,
+            address
+        }]).then((result) => {
+            dispatch({
+                type: 'ACCOUNT/UPDATE_ACCOUNT',
+                address,
+                name,
+                description,
+            });
+        });
+}
+
 export function sendTransaction(accountId, password, to, gas, gasPrice, value) {
     return (dispatch) =>
         rpc.call('eth_sendTransaction', [{

--- a/src/store/accountReducers.js
+++ b/src/store/accountReducers.js
@@ -86,6 +86,16 @@ function onSetAccountsList(state, action) {
     }
 }
 
+function onUpdateAccount(state, action) {
+    if (action.type === 'ACCOUNT/UPDATE_ACCOUNT') {
+        return updateAccount(state, action.address, (acc) =>
+            acc.set('name', action.name)
+                .set('description', action.description)
+        );
+    }
+    return state;
+}
+
 function onSetBalance(state, action) {
     if (action.type === 'ACCOUNT/SET_BALANCE') {
         return updateAccount(state, action.accountId, (acc) =>
@@ -213,6 +223,7 @@ export default function accountsReducers(state, action) {
     state = onLoading(state, action);
     state = onSetAccountsList(state, action);
     state = onAddAccount(state, action);
+    state = onUpdateAccount(state, action);
     state = onSetBalance(state, action);
     state = onSetTxCount(state, action);
     state = onSetTokenBalance(state, action);


### PR DESCRIPTION
Addresses issues in #131:
show success/error, show address info, load balance, add to acct list

Currently, `AccountShow` is displayed as a card on the screen, below the "success" message. In the future, if we have a notifications UI, the "success" message can go in the notifications center and then redirect straight to `AccountShow`