### PR TITLE
Tx histories

### DIFF
--- a/src/components/accounts/account.js
+++ b/src/components/accounts/account.js
@@ -2,35 +2,43 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { TableRow, TableRowColumn } from 'material-ui/Table';
+import FontIcon from 'material-ui/FontIcon';
 import { gotoScreen } from 'store/screenActions';
 import log from 'loglevel';
-import { link, tables } from 'lib/styles';
+import copy from 'copy-to-clipboard';
+import { link, tables, copyIcon } from 'lib/styles';
 import AccountPopup from './popup';
 
-const Render = ({ account, openAccount }) => (
+const Render = ({ account, openAccount }) => {
+    function copyAccountToClipBoard() {
+        copy(account.get('id'));
+    }
+
+    return (
     <TableRow selectable={false} >
-        <TableRowColumn xs={3} >
+        <TableRowColumn >
             <span style={link} onClick={openAccount}>
                 {account.get('name')}
             </span>
         </TableRowColumn>
-        <TableRowColumn xs={5} >
+        <TableRowColumn >
+            <FontIcon className='fa fa-clone' onClick={copyAccountToClipBoard} style={copyIcon} />
             <span style={link} onClick={openAccount}>
                 {account.get('id')}
             </span>
         </TableRowColumn>
-        <TableRowColumn xs={3}>
+        <TableRowColumn>
             <span style={link}>
                 {account.get('balance') ? account.get('balance').getEther() : '?'} Ether
             </span>
         </TableRowColumn>
-        <TableRowColumn xs={1} >
+        <TableRowColumn >
             <span>
             <AccountPopup account={account}/>
             </span>
         </TableRowColumn>
-    </TableRow>
-);
+    </TableRow>);
+};
 
 Render.propTypes = {
     account: PropTypes.object.isRequired,

--- a/src/components/accounts/list.js
+++ b/src/components/accounts/list.js
@@ -16,10 +16,10 @@ const Render = translate('accounts')(({ t, accounts, createAccount }) => {
     const table = <Table selectable={false}>
         <TableHeader displaySelectAll={false} adjustForCheckbox={false}>
             <TableRow>
-                <TableHeaderColumn xs={3}>Account</TableHeaderColumn>
-                <TableHeaderColumn xs={5}>Address</TableHeaderColumn>
-                <TableHeaderColumn xs={3}>Balance</TableHeaderColumn>
-                <TableHeaderColumn xs={1}>Add Ether</TableHeaderColumn>
+                <TableHeaderColumn>Account</TableHeaderColumn>
+                <TableHeaderColumn>Address</TableHeaderColumn>
+                <TableHeaderColumn>Balance</TableHeaderColumn>
+                <TableHeaderColumn>Add Ether</TableHeaderColumn>
             </TableRow>
         </TableHeader>
         <TableBody displayRowCheckbox={false}>

--- a/src/components/accounts/popup.js
+++ b/src/components/accounts/popup.js
@@ -12,7 +12,7 @@ import copy from 'copy-to-clipboard';
 import { Row, Col } from 'react-flexbox-grid/lib/index';
 import { DescriptionList, DescriptionTitle, DescriptionData } from 'elements/dl';
 import { link, align, cardSpace, copyIcon } from 'lib/styles';
-import { Wei, GASPRICE_ESTIMATE } from 'lib/types';
+import { Wei } from 'lib/types';
 
 /**
  * Dialog with action buttons. The actions are passed in as an array of React objects,
@@ -158,10 +158,11 @@ const AccountPopup = connect(
         const accounts = state.accounts.get('accounts');
         const pos = accounts.findKey((acc) => acc.get('id') === ownProps.account.get('id'));
         const rates = state.accounts.get('rates');
+        const gasPrice = state.accounts.get('gasPrice');
         return {
             account: (accounts.get(pos) || Immutable.Map({})),
             rates,
-            gasPrice: GASPRICE_ESTIMATE,
+            gasPrice,
         };
     },
     (dispatch, ownProps) => ({})

--- a/src/components/accounts/popup.js
+++ b/src/components/accounts/popup.js
@@ -126,7 +126,9 @@ class AccountPopupRender extends React.Component {
 
                     <p style={styles.usageText}>
                         Share your wallet address and use it to top up your wallet with BTC from any
-                        &nbsp;<a href='https://shapeshift.io' >other service</a>. All BTC will be converted to ETC.
+                        &nbsp;<a href='https://shapeshift.io' target='_blank' >other service
+                        <sup><FontIcon className='fa fa-external-link' style={{fontSize: '0.6rem'}} /></sup>
+                        </a>. All BTC will be converted to ETC.
                         It may take some time for your coins be deposited.
                     </p>
 

--- a/src/components/accounts/popup.js
+++ b/src/components/accounts/popup.js
@@ -11,8 +11,8 @@ import FontIcon from 'material-ui/FontIcon';
 import copy from 'copy-to-clipboard';
 import { Row, Col } from 'react-flexbox-grid/lib/index';
 import { DescriptionList, DescriptionTitle, DescriptionData } from 'elements/dl';
-import { link, align, cardSpace } from 'lib/styles';
-import { Wei } from 'lib/types';
+import { link, align, cardSpace, copyIcon } from 'lib/styles';
+import { Wei, GASPRICE_ESTIMATE } from 'lib/types';
 
 /**
  * Dialog with action buttons. The actions are passed in as an array of React objects,
@@ -71,12 +71,6 @@ class AccountPopupRender extends React.Component {
             display: 'inline',
             fontSize: '0.8rem', /* to better ensure fit for all screen sizes */
         },
-        copyIcon: {
-            display: 'inline',
-            fontSize: '0.9rem',
-            color: 'darkgray',
-            marginLeft: '0.3rem',
-        },
     };
 
     function copyAccountToClipBoard() {
@@ -120,7 +114,7 @@ class AccountPopupRender extends React.Component {
                             <code style={styles.accountId}>
                             {account.get('id')}
                             </code>
-                            <FontIcon className='fa fa-clone' onClick={copyAccountToClipBoard} style={Object.assign({}, link, styles.copyIcon)} />
+                            <FontIcon className='fa fa-clone' onClick={copyAccountToClipBoard} style={copyIcon} />
                             </span>
                         </DescriptionData>
                     </DescriptionList>
@@ -162,11 +156,10 @@ const AccountPopup = connect(
         const accounts = state.accounts.get('accounts');
         const pos = accounts.findKey((acc) => acc.get('id') === ownProps.account.get('id'));
         const rates = state.accounts.get('rates');
-        const gasPrice = new Wei(21338000000); // Rough estimate tx gasprice; 21000 * 10^6
         return {
             account: (accounts.get(pos) || Immutable.Map({})),
             rates,
-            gasPrice,
+            gasPrice: GASPRICE_ESTIMATE,
         };
     },
     (dispatch, ownProps) => ({})

--- a/src/components/layout/total.js
+++ b/src/components/layout/total.js
@@ -32,11 +32,11 @@ const Render = ({ total, fiat, currentLocaleCurrency }) => {
             <Row>
                 <Col xs={12} style={fiatSubtitle}>
                     <span style={valueDisplay}>
-                        ${renderAsCurrency(fiat.total.localized)}
+                        {renderAsCurrency(fiat.total.localized)}
                     </span>
                     &bull;
                     <span style={valueDisplay}>
-                        ${renderAsCurrency(fiat.rate.localized)} ETC/{currentLocaleCurrency.toUpperCase()}
+                        {renderAsCurrency(fiat.rate.localized)} ETC/{currentLocaleCurrency.toUpperCase()}
                     </span>
                 </Col>
             </Row>
@@ -103,7 +103,7 @@ const Total = connect(
         }
 
         return {
-            total: totalEther,
+            total: +totalEther,
             fiat,
             currentLocaleCurrency,
         };

--- a/src/components/tx/create.js
+++ b/src/components/tx/create.js
@@ -70,7 +70,7 @@ const CreateTx = connect(
     (state, ownProps) => {
         const selector = formValueSelector('createTx');
         const tokens = state.tokens.get('tokens');
-        const balance = ownProps.account.get('balance');
+        const balance = ownProps.account.get('balance').getEther(6);
         const gasPrice = state.accounts.get('gasPrice').getMwei();
         return {
             initialValues: {

--- a/src/components/tx/createTxForm.js
+++ b/src/components/tx/createTxForm.js
@@ -40,7 +40,7 @@ const Render = (props) => {
 
       <CardText expandable={false}>
         <Row>
-          <Col xs={12} md={6}>
+          <Col xs={12} md={8}>
             <Row>
               <Col xs={12}>
                 <Field name="from"
@@ -71,18 +71,23 @@ const Render = (props) => {
               </Col>
             </Row>
             <Row>
-              <Col xs={12}>
+              <Col xs={11}>
                 <Field name="to"
                        component={TextField}
                        floatingLabelText="Target Address"
                        validate={[required, address]}
+                       fullWidth={true}
                 />
+              </Col>
+              <Col xs={1}>
                 <IconMenu
                     iconButtonElement={<IconButton><ImportContacts /></IconButton>}
                     onItemTouchTap={handleSelect}
                 >
                 {accounts.map((account) =>
-                  <MenuItem key={account.get('id')} value={account.get('id')} primaryText={account.get('id')} />
+                  <MenuItem key={account.get('id')}
+                    value={account.get('id')}
+                    primaryText={account.get('name') ? account.get('name') : account.get('id')} />
                 )}
                 <Divider />
                 {addressBook.map((account) =>
@@ -127,7 +132,7 @@ const Render = (props) => {
             </Row>
           </Col>
 
-          <Col xs={12} md={6}>
+          <Col xs={12} md={4}>
             <Row>
               <Col xs={12}>
                 <Field name="gasPrice"

--- a/src/components/tx/list.js
+++ b/src/components/tx/list.js
@@ -5,6 +5,7 @@ import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow } from 'mate
 import { Card, CardHeader, CardText } from 'material-ui/Card';
 import FontIcon from 'material-ui/FontIcon';
 import Avatar from 'material-ui/Avatar';
+import log from 'loglevel';
 import { cardSpace, tables } from 'lib/styles';
 import Immutable from 'immutable';
 import Transaction from './transaction';
@@ -24,8 +25,9 @@ const Render = ({ transactions }) => {
     const table = <Table selectable={false}>
         <TableHeader displaySelectAll={false} adjustForCheckbox={false}>
             <TableRow>
+                <TableHeaderColumn style={tables.shortStyle}>Block</TableHeaderColumn>
+                <TableHeaderColumn style={tables.wideStyle}>Hash</TableHeaderColumn>
                 <TableHeaderColumn style={tables.shortStyle}>Amount</TableHeaderColumn>
-                <TableHeaderColumn style={tables.shortStyle}>Date</TableHeaderColumn>
                 <TableHeaderColumn style={tables.wideStyle}>From</TableHeaderColumn>
                 <TableHeaderColumn style={tables.wideStyle}>To</TableHeaderColumn>
                 <TableHeaderColumn style={tables.shortStyle}></TableHeaderColumn>
@@ -63,6 +65,7 @@ Render.propTypes = {
 const TransactionsList = connect(
     (state, ownProps) => {
         const transactions = state.accounts.get('trackedTransactions', Immutable.List());
+        // log.debug('transactions', transactions, (typeof transactions));
         return {
             transactions,
         };

--- a/src/components/tx/list.js
+++ b/src/components/tx/list.js
@@ -59,7 +59,7 @@ const Render = ({ transactions }) => {
 };
 
 Render.propTypes = {
-    transactions: PropTypes.array.isRequired,
+    transactions: PropTypes.object.isRequired,
 };
 
 const TransactionsList = connect(

--- a/src/components/tx/list.js
+++ b/src/components/tx/list.js
@@ -64,10 +64,10 @@ Render.propTypes = {
 
 const TransactionsList = connect(
     (state, ownProps) => {
-        const transactions = state.accounts.get('trackedTransactions', Immutable.List());
-        // log.debug('transactions', transactions, (typeof transactions));
+        const transactionsAccounts = state.accounts.get('trackedTransactions', Immutable.List());
+        const txs = ownProps.transactions || transactionsAccounts;
         return {
-            transactions,
+            transactions: txs.reverse(),
         };
     },
     (dispatch, ownProps) => ({

--- a/src/components/tx/show.js
+++ b/src/components/tx/show.js
@@ -96,10 +96,12 @@ const TransactionShow = connect(
            (acct) => acct.get('id') === ownProps.accountId
         );
         const rates = state.accounts.get('rates');
+        const Tx = state.accounts.get('trackedTransactions').find(
+            (tx) => tx.get('hash') === ownProps.hash
+        );
         return {
-            transaction: state.accounts.get('trackedTransactions').find(
-                (tx) => tx.get('hash') === ownProps.hash
-            ),
+            hash: Tx.get('hash'),
+            transaction: Tx,
             account: (account === undefined) ? undefined : account,
             accounts,
             rates,

--- a/src/components/tx/transaction.js
+++ b/src/components/tx/transaction.js
@@ -29,12 +29,17 @@ const Render = ({ tx, openTx, accounts, openAccount, refreshTx }) => {
         <TableRow selectable={false}>
             <TableRowColumn style={tables.shortStyle}>
                     <span onClick={openTx} style={link}>
-                        {tx.get('value') ? tx.get('value').getEther() : '?'} Ether
+                        {tx.get('blockNumber') ? tx.get('blockHash') : 'PENDING' }
+                    </span>
+            </TableRowColumn>
+            <TableRowColumn style={tables.wideStyle}>
+                    <span onClick={openTx} style={link}>
+                        {tx.get('hash')}
                     </span>
             </TableRowColumn>
             <TableRowColumn style={tables.shortStyle}>
                     <span onClick={openTx} style={link}>
-                        {tx.get('timestamp') ? toDuration(tx.get('timestamp')) : 'pending'}
+                        {tx.get('value') ? tx.get('value').getEther() : '?'} Ether
                     </span>
             </TableRowColumn>
             <TableRowColumn style={tables.wideStyle}>

--- a/src/components/tx/transaction.js
+++ b/src/components/tx/transaction.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import Immutable from 'immutable';
 import { TableRow, TableRowColumn } from 'material-ui/Table';
 import { gotoScreen } from 'store/screenActions';
-import { refreshTransactions } from 'store/accountActions';
+import { refreshTransaction } from 'store/accountActions';
 import FontIcon from 'material-ui/FontIcon';
 import log from 'loglevel';
 import { link, tables } from 'lib/styles';
@@ -84,7 +84,7 @@ const Transaction = connect(
         },
         refreshTx: () => {
             const hash = ownProps.tx.get('hash');
-            dispatch(refreshTransactions(hash));
+            dispatch(refreshTransaction(hash));
         },
     })
 )(Render);

--- a/src/components/tx/transaction.js
+++ b/src/components/tx/transaction.js
@@ -60,9 +60,8 @@ const Render = ({ tx, openTx, accounts, openAccount, refreshTx }) => {
 };
 
 Render.propTypes = {
-    hash: PropTypes.string.isRequired,
     tx: PropTypes.object.isRequired,
-    accounts: PropTypes.array.isRequired,
+    accounts: PropTypes.object.isRequired,
     openAccount: PropTypes.func.isRequired,
     openTx: PropTypes.func.isRequired,
     refreshTx: PropTypes.func.isRequired,

--- a/src/lib/convert.js
+++ b/src/lib/convert.js
@@ -10,6 +10,9 @@ export function toNumber(quantity) {
     if (quantity === '0x') {
         return 0;
     }
+    if (typeof quantity !== 'string') {
+        quantity = quantity.toString();
+    }
     return parseInt(quantity.substring(2), 16);
 }
 
@@ -46,7 +49,7 @@ export function toDuration(timestamp) {
 
 //TODO: Handle locales
 export function toDate(timestamp) {
-    return new Date(timestamp).toJSON(); 
+    return new Date(timestamp).toJSON();
 }
 
 export function parseString(hex) {

--- a/src/lib/rpcApi.js
+++ b/src/lib/rpcApi.js
@@ -33,12 +33,15 @@ export class RpcApi {
     call(name, params, headers) {
         return new Promise((resolve, reject) => {
             this.jsonPost(name, params, headers).then((json) => {
-                if (json.result) {
+                // eth_syncing will return {.. "result": false}
+                if (json.result || json.result === false) {
                     resolve(json.result);
                 } else if (json.error) {
                     reject(json.error);
                 } else {
-                    reject(new Error(`Unknown JSON RPC response: ${json}`));
+                    reject(new Error(`Unknown JSON RPC response: ${JSON.stringify(json)},
+                     name: ${name},
+                     params: ${JSON.stringify(params)}`));
                 }
             }).catch((error) => reject(error));
         });

--- a/src/lib/styles.js
+++ b/src/lib/styles.js
@@ -24,6 +24,15 @@ export const code = {
     maxHeight: '250px',
 };
 
+export const copyIcon = {
+    display: 'inline',
+    fontSize: '0.9rem',
+    color: 'darkgray',
+    marginLeft: '0.3rem',
+    marginRight: '0.3rem',
+    cursor: 'pointer',
+};
+
 export const align = {
     left: { textAlign: 'left' },
     center: { textAlign: 'center'},

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -81,6 +81,9 @@ export class Wei extends Immutable.Record({ val: ZERO }) {
     }
 }
 
+// TODO: get from gastracker api?
+export const GASPRICE_ESTIMATE = new Wei(23000000000);
+
 export class TokenUnits extends Immutable.Record({ val: ZERO,
     divisor: ONE }) {
     constructor(val, decimal) {

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -81,9 +81,6 @@ export class Wei extends Immutable.Record({ val: ZERO }) {
     }
 }
 
-// TODO: get from gastracker api?
-export const GASPRICE_ESTIMATE = new Wei(23000000000);
-
 export class TokenUnits extends Immutable.Record({ val: ZERO,
     divisor: ONE }) {
     constructor(val, decimal) {

--- a/src/store/accountActions.js
+++ b/src/store/accountActions.js
@@ -1,7 +1,9 @@
+import log from 'loglevel';
 import { rpc } from 'lib/rpc';
 import { getRates } from 'lib/marketApi';
 import { address } from 'lib/validators';
 import { loadTokenBalanceOf } from './tokenActions';
+
 
 export function loadAccountBalance(accountId) {
     return (dispatch, getState) => {
@@ -167,26 +169,6 @@ export function importWallet(wallet, name, description) {
     };
 }
 
-export function refreshTransaction(hash) {
-    return (dispatch) =>
-        rpc.call('eth_getTransactionByHash', [hash]).then((result) => {
-            if (typeof result === 'object') {
-                dispatch({
-                    type: 'ACCOUNT/UPDATE_TX',
-                    tx: result,
-                });
-                /** TODO: Check for input data **/
-                if ((result.creates !== undefined) && (address(result.creates) === undefined)) {
-                    dispatch({
-                        type: 'CONTRACT/UPDATE_CONTRACT',
-                        tx: result,
-                        address: result.creates,
-                    });
-                }
-            }
-        });
-}
-
 export function loadPendingTransactions() {
     return (dispatch, getState) =>
         rpc.call('eth_getBlockByNumber', ['pending', true])
@@ -219,11 +201,32 @@ export function loadPendingTransactions() {
             });
 }
 
+export function refreshTransaction(hash) {
+    return (dispatch) =>
+        rpc.call('eth_getTransactionByHash', [hash]).then((result) => {
+            if (typeof result === 'object') {
+                dispatch({
+                    type: 'ACCOUNT/UPDATE_TX',
+                    tx: result,
+                });
+                /** TODO: Check for input data **/
+                if ((result.creates !== undefined) && (address(result.creates) === undefined)) {
+                    dispatch({
+                        type: 'CONTRACT/UPDATE_CONTRACT',
+                        tx: result,
+                        address: result.creates,
+                    });
+                }
+            }
+        });
+}
+
 export function refreshTrackedTransactions() {
-    return (dispatch, getState) =>
+    return (dispatch, getState) => {
         getState().accounts.get('trackedTransactions').map(
             (tx) => dispatch(refreshTransaction(tx.get('hash')))
         );
+    };
 }
 
 export function trackTx(tx) {

--- a/src/store/accountActions.js
+++ b/src/store/accountActions.js
@@ -1,9 +1,8 @@
-import log from 'loglevel';
+import Immutable from 'immutable';
 import { rpc } from 'lib/rpc';
 import { getRates } from 'lib/marketApi';
 import { address } from 'lib/validators';
 import { loadTokenBalanceOf } from './tokenActions';
-
 
 export function loadAccountBalance(accountId) {
     return (dispatch, getState) => {
@@ -169,6 +168,21 @@ export function importWallet(wallet, name, description) {
     };
 }
 
+function loadStoredTransactions() {
+    return (dispatch) => {
+        if (localStorage) {
+            const storedTxs = localStorage.getItem('trackedTransactions');
+            if (storedTxs !== null) {
+                const storedTxsJSON = JSON.parse(storedTxs);
+                dispatch({
+                    type: 'ACCOUNT/LOAD_STORED_TXS',
+                    transactions: storedTxsJSON,
+                });
+            }
+        }
+    };
+}
+
 export function loadPendingTransactions() {
     return (dispatch, getState) =>
         rpc.call('eth_getBlockByNumber', ['pending', true])
@@ -182,6 +196,7 @@ export function loadPendingTransactions() {
                     type: 'ACCOUNT/PENDING_TX',
                     txList: txes,
                 });
+                dispatch(loadStoredTransactions());
                 for (const tx of txes) {
                     const disp = {
                         type: 'ACCOUNT/PENDING_BALANCE',

--- a/src/store/accountActions.js
+++ b/src/store/accountActions.js
@@ -167,7 +167,7 @@ export function importWallet(wallet, name, description) {
     };
 }
 
-export function refreshTransactions(hash) {
+export function refreshTransaction(hash) {
     return (dispatch) =>
         rpc.call('eth_getTransactionByHash', [hash]).then((result) => {
             if (typeof result === 'object') {
@@ -222,7 +222,7 @@ export function loadPendingTransactions() {
 export function refreshTrackedTransactions() {
     return (dispatch, getState) =>
         getState().accounts.get('trackedTransactions').map(
-            (tx) => dispatch(refreshTransactions(tx.get('hash')))
+            (tx) => dispatch(refreshTransaction(tx.get('hash')))
         );
 }
 

--- a/src/store/accountReducers.js
+++ b/src/store/accountReducers.js
@@ -1,13 +1,13 @@
 import Immutable from 'immutable';
 import log from 'loglevel';
-import { Wei, TokenUnits, GASPRICE_ESTIMATE } from '../lib/types';
+import { Wei, TokenUnits } from '../lib/types';
 import { toNumber } from '../lib/convert';
 
 const initial = Immutable.fromJS({
     accounts: [],
     trackedTransactions: [],
     loading: false,
-    gasPrice: GASPRICE_ESTIMATE,
+    gasPrice: new Wei(23000000000),
     rates: {},
 });
 

--- a/src/store/accountReducers.js
+++ b/src/store/accountReducers.js
@@ -1,12 +1,13 @@
 import Immutable from 'immutable';
-import { Wei, TokenUnits } from '../lib/types';
+import log from 'loglevel';
+import { Wei, TokenUnits, GASPRICE_ESTIMATE } from '../lib/types';
 import { toNumber } from '../lib/convert';
 
 const initial = Immutable.fromJS({
     accounts: [],
     trackedTransactions: [],
     loading: false,
-    gasPrice: new Wei(23000000000),
+    gasPrice: GASPRICE_ESTIMATE,
     rates: {},
 });
 

--- a/src/store/tokenActions.js
+++ b/src/store/tokenActions.js
@@ -37,7 +37,7 @@ const TokenAbi = [
         ];
 
 function getFunction(name) {
-    return Immutable.fromJS( 
+    return Immutable.fromJS(
         TokenAbi.find((f) => (f.name === name))
         );
 }
@@ -136,10 +136,10 @@ export function addToken(address, name) {
 function createTokenTransaction(token, to, value, isTransfer) {
     const address = getNakedAddress(to);
     const numTokens = fromTokens(value, token.get('decimals'));
-    if (isTransfer === 'true') 
+    if (isTransfer === 'true')
         return functionToData(getFunction('transfer'),
             { _to: address, _value: numTokens });
-    else 
+    else
         return functionToData(getFunction('approve'),
             { _spender: address, _amount: numTokens });
 }


### PR DESCRIPTION
- Implements tx history display for account pages
- Implements persistent tx history via `localStorage`, which wasn't slated for Beta but was slowing down my development process. If would rather leave out of this release I'm happy keeping the changes just on my machine in my `git stash` of goodies.
- Fixes transactions not updating from 'PENDING'
- Fixes extra "$" in `total.js`, which was due to me developing on Safari (fixed with Chrome) - Safari didn't like `toLocaleString()`
- Fixes create Tx form balance field from looking weird
- Changes formatting on create Tx form to give more space to `To` address field.
- Fixes rpc erroring on receiving `result: false` from `eth_sync` call
- Fixes a couple of `PropType.array.isRequired` cases that should have been `.object.` because they're `Immutable`

- Makes tx histories (main and account) shown in "reverse" order, with newest on top

- Made me aware that the "copy-to-clipboard" link/+icon doesn't work in Chrome, though the npm package description claims that it should...

As usual, happy for any feedback.
