### PR TITLE
welcome screen & footer revisions

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -33,12 +33,12 @@ const store = new Store({
     defaults: {
         firstRun: true,
     },
-    name: 'launcher'
+    name: 'launcher',
 });
 
 global.launcherConfig = {
     firstRun: store.get('firstRun'),
-    chain: store.get('chain')
+    chain: store.get('chain'),
 };
 
 console.log('firstRun', store.get('firstRun'));

--- a/electron/mainWindow.js
+++ b/electron/mainWindow.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const url = require('url');
-import {BrowserWindow, Menu} from 'electron';
+import {BrowserWindow, Menu, shell } from 'electron';
 import winLinuxMenu from './menus/win-linux';
 // import icon from './icons/background.png';
 
@@ -25,6 +25,11 @@ export function createWindow (openDevTools) {
     mainWindow.webContents.openDevTools();
     require('devtron').install();
   }
+    // https://stackoverflow.com/questions/32402327/how-can-i-force-external-links-from-browser-window-to-open-in-a-default-browser
+    mainWindow.webContents.on('will-navigate', function(e, url) {
+      e.preventDefault();
+      shell.openExternal(url);
+    });
 
   // Emitted when the window is closed.
   mainWindow.on('closed', () => {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build:watch": "node build",
     "build:electron": "node build --for-electron",
     "start:electron": "npm run build:electron & NODE_ENV=development ./node_modules/.bin/electron -r babel-register -r babel-polyfill .",
-    "start": "node ./node_modules/.bin/webpack-dev-server --content-base build/ --inline  --port 8000",
+    "start": "node ./node_modules/.bin/webpack-dev-server --content-base build/ --inline --port 8000",
     "test:watch": "node ./node_modules/karma/bin/karma start",
     "test": "npm run build && node ./node_modules/karma/bin/karma start --single-run",
     "lint": "./node_modules/eslint/bin/eslint.js ./src/",

--- a/src/components/layout/footer.js
+++ b/src/components/layout/footer.js
@@ -38,7 +38,7 @@ const Render = () => {
             <Col xs={8} middle='xs' style={{color: 'gray', fontWeight: '300'}}>
                 <p style={{marginTop: 0}}>
                 Find an issue? Got a suggestion? <br/>
-                Please let us know on our <a target='_blank' href='//github.com/ethereumproject/emerald-wallet/issues'>
+                Please let us know on our <a target='_blank' href='https://github.com/ethereumproject/emerald-wallet/issues'>
                 Github issues page</a>.
                 </p>
                 <p>

--- a/src/components/layout/footer.js
+++ b/src/components/layout/footer.js
@@ -35,21 +35,19 @@ const Render = () => {
             <Col xs={2} style={{color: 'limegreen'}}>
                 Beta 0.0.1
             </Col>
-            <Col xs={8} middle='xs' style={{color: 'gray'}}>
+            <Col xs={8} middle='xs' style={{color: 'gray', fontWeight: '300'}}>
                 <p style={{marginTop: 0}}>
-                Welcome to Emerald Wallet Beta. Thanks for trying it out!<br/>
-                We're anticipating an Alpha release by July 20th.
-                In the meantime, you're encouraged to submit issues
-                as well as suggestions to our <a target='_blank' href='//github.com/ethereumproject/emerald-wallet/issues'>
-                issues page</a>.
+                Find an issue? Got a suggestion? <br/>
+                Please let us know on our <a target='_blank' href='//github.com/ethereumproject/emerald-wallet/issues'>
+                Github issues page</a>.
                 </p>
                 <p>
-                Made with ❤️&nbsp; by <strong>ETCDEV</strong> and <a target='_blank' href='https://github.com/ethereumproject/emerald-wallet/network/members'> wonderful contributors</a>.
+                Made with ❤️&nbsp; by <strong>ETCDEV</strong> and <a target='_blank' href='https://github.com/ethereumproject/emerald-wallet/network/members'>many wonderful contributors</a>.
                 </p>
             </Col>
             <Col xs={2} style={align.right} middle="xs">
 
-                <FlatButton label="On GitHub"
+                <FlatButton label="Source"
                     labelPosition="before"
                     href="https://github.com/ethereumproject/emerald-wallet"
                     icon={<FontIcon className="fa fa-github" />}/>

--- a/src/components/layout/footer.js
+++ b/src/components/layout/footer.js
@@ -33,7 +33,7 @@ const Render = () => {
     return (
         <Row style={{...styles.footerDiv}}>
             <Col xs={2} style={{color: 'limegreen'}}>
-                Beta 0.0.1i
+                Beta 0.0.1
             </Col>
             <Col xs={8} style={{color: 'gray', fontWeight: '300'}}>
                 <p style={{marginTop: 0}}>

--- a/src/components/layout/footer.js
+++ b/src/components/layout/footer.js
@@ -33,9 +33,9 @@ const Render = () => {
     return (
         <Row style={{...styles.footerDiv}}>
             <Col xs={2} style={{color: 'limegreen'}}>
-                Beta 0.0.1
+                Beta 0.0.1i
             </Col>
-            <Col xs={8} middle='xs' style={{color: 'gray', fontWeight: '300'}}>
+            <Col xs={8} style={{color: 'gray', fontWeight: '300'}}>
                 <p style={{marginTop: 0}}>
                 Find an issue? Got a suggestion? <br/>
                 Please let us know on our <a target='_blank' href='https://github.com/ethereumproject/emerald-wallet/issues'>
@@ -45,7 +45,7 @@ const Render = () => {
                 Made with ❤️&nbsp; by <strong>ETCDEV</strong> and <a target='_blank' href='https://github.com/ethereumproject/emerald-wallet/network/members'>many wonderful contributors</a>.
                 </p>
             </Col>
-            <Col xs={2} style={align.right} middle="xs">
+            <Col xs={2} style={align.right}>
 
                 <FlatButton label="Source"
                     labelPosition="before"

--- a/src/components/layout/navigation.js
+++ b/src/components/layout/navigation.js
@@ -53,7 +53,7 @@ Render.propTypes = {
 
 const Navigation = connect(
     (state, ownProps) => ({
-        chain: (state.network.get('chain') || {}).get('name'),
+        chain: (state.network.get('chain') || {}).get('name') || '',
     }),
     (dispatch, ownProps) => ({
         openAccounts: () => {

--- a/src/components/layout/status.js
+++ b/src/components/layout/status.js
@@ -75,7 +75,7 @@ const Status = connect(
         return {
             block: curBlock,
             progress: ((curBlock / tip) * 100),
-            chain: (state.network.get('chain') || {}).get('title'),
+            chain: (state.network.get('chain') || {}).get('title') || '',
             peerCount,
         };
         // syncing: state.network.get('sync');

--- a/src/components/layout/total.js
+++ b/src/components/layout/total.js
@@ -99,7 +99,7 @@ const Total = connect(
         } else {
             currentLocaleCurrency = 'USD';
             fiat.total.localized = fiat.total.usd;
-            fiat.rate.localized = +fiat.rate.usd || 0; // fiat.pair.usd;
+            fiat.rate.localized = +fiat.rate.usd; // fiat.pair.usd;
         }
 
         return {

--- a/src/components/layout/total.js
+++ b/src/components/layout/total.js
@@ -36,7 +36,7 @@ const Render = ({ total, fiat, currentLocaleCurrency }) => {
                     </span>
                     &bull;
                     <span style={valueDisplay}>
-                        {renderAsCurrency(fiat.rate.localized)} ETC/{currentLocaleCurrency.toUpperCase()}
+                        {fiat.rate.localized ? renderAsCurrency(fiat.rate.localized) : '?'} ETC/{currentLocaleCurrency.toUpperCase()}
                     </span>
                 </Col>
             </Row>

--- a/src/components/main.js
+++ b/src/components/main.js
@@ -13,21 +13,26 @@ import Footer from './layout/footer';
 
 const Render = translate('common')(({t, ...props}) => (
     <Grid>
+    {props.screen !== 'welcome' &&
+
         <Row>
             <Col xs={12}>
                 <Header/>
             </Col>
         </Row>
+    }
         <Row>
             <Col xs={12}>
                 <Screen id="body"/>
             </Col>
         </Row>
+    {props.screen !== 'welcome' &&
         <Row>
             <Col xs={12}>
                 <Footer />
             </Col>
         </Row>
+    }
     </Grid>
 ));
 

--- a/src/components/screen.js
+++ b/src/components/screen.js
@@ -10,7 +10,7 @@ import AddressAdd from './addressbook/add';
 import CreateTx from './tx/create';
 import TransactionShow from './tx/show';
 import TransactionsList from './tx/list';
-import TokensList from './tokens/list';
+// import TokensList from './tokens/list';
 import AddToken from './tokens/add';
 import CreateAccount from './accounts/add/add';
 import GenerateAccount from './accounts/add/generate';

--- a/src/components/welcome.js
+++ b/src/components/welcome.js
@@ -8,7 +8,7 @@ import { cardSpace } from 'lib/styles';
 import { gotoScreen } from 'store/screenActions';
 import logo from 'images/etc_logo.png';
 
-const Render = ({ message, level, ready }) => {
+const Render = ({ message, level, ready, gohome, isFirstRun }) => {
 
     let messageStyle = {
         color: "#999"
@@ -21,33 +21,53 @@ const Render = ({ message, level, ready }) => {
     if (ready) {
         readyActions = (
             <FlatButton label="Open Wallet"
-                        icon={<FontIcon className="fa fa-play-circle" />}/>
+                        icon={<FontIcon className="fa fa-play-circle" />}
+                        style={{backgroundColor: 'limegreen', color: 'white'}}
+                        onClick={gohome}/>
         );
     }
 
 
     return (
         <Grid id="welcome-screen">
-            <Row center="xs" style={{paddingTop: "100px"}}>
+            <Row center="xs" style={{paddingTop: '150px'}}>
                 <Col xs>
                     <img src={logo} height={128}/>
                 </Col>
             </Row>
-            <Row center="xs" style={{paddingTop: "40px"}}>
-                <Col xs>
-                    <span style={{fontSize: "28px", fontWeight: 900}}>Emerald Wallet</span>
-                </Col>
-            </Row>
-            <Row center="xs" style={{paddingTop: "40px", height: "40px"}}>
-                <Col xs>
-                    <span style={messageStyle}><i className="fa fa-spin fa-spinner"/> {message}</span>
-                </Col>
-            </Row>
-            <Row end="xs" style={{paddingTop: "170px"}}>
-                <Col xs={6}>
+            {!ready &&
+                <div>
+                <Row center="xs" style={{paddingTop: "40px"}}>
+                    <Col xs>
+                        <span style={{fontSize: "28px", fontWeight: 900}}>Emerald Wallet</span>
+                    </Col>
+                </Row>
+                <Row center="xs" style={{paddingTop: "40px", height: "40px"}}>
+                     <Col xs>
+                         <span style={messageStyle}><i className="fa fa-spin fa-spinner"/> {message}</span>
+                     </Col>
+                 </Row>
+                 </div>
+            }
+            {ready &&
+                <Row center="xs" style={{paddingTop: '40px'}}>
+                    <Col xs={8}>
+                    {
+                    isFirstRun &&
+                        <div style={{fontWeight: '300'}}>
+                        <p>
+                        Welcome to Emerald Wallet Beta. Thanks for trying it out!<br/>
+                        We are anticipating an Alpha release by July 20th.
+                        </p>
+                        <p>
+                        Made with ❤️&nbsp; by <strong>ETCDEV</strong> and <strong>many wonderful contributors</strong>.
+                        </p>
+                        </div>
+                    }
                     {readyActions}
-                </Col>
-            </Row>
+                    </Col>
+                </Row>
+            }
         </Grid>
     );
 };
@@ -56,6 +76,8 @@ Render.propTypes = {
     message: PropTypes.string.isRequired,
     level: PropTypes.number.isRequired,
     ready: PropTypes.bool.isRequired,
+    gohome: PropTypes.func.isRequired,
+    isFirstRun: PropTypes.bool.isRequired,
 };
 
 const Welcome = connect(
@@ -63,9 +85,13 @@ const Welcome = connect(
         message: state.launcher.getIn(["message", "text"]),
         level: state.launcher.getIn(["message", "level"]),
         ready: state.launcher.getIn(["status", "geth"]) === "ready"
-                && state.launcher.getIn(["status", "connector"]) === "ready"
+                && state.launcher.getIn(["status", "connector"]) === "ready",
+        isFirstRun: state.launcher.get('firstRun'),
     }),
     (dispatch, ownProps) => ({
+         gohome: () => {
+            dispatch(gotoScreen('home'));
+        }
     })
 )(Render);
 

--- a/src/components/welcome.js
+++ b/src/components/welcome.js
@@ -57,7 +57,7 @@ const Render = ({ message, level, ready, gohome, isFirstRun }) => {
                         <div style={{fontWeight: '300'}}>
                         <p>
                         Welcome to Emerald Wallet Beta. Thanks for trying it out!<br/>
-                        We are anticipating an Alpha release by July 20th.
+                        We're looking forward to an Alpha release by July 20th.
                         </p>
                         <p>
                         Made with ❤️&nbsp; by <strong>ETCDEV</strong> and <strong>many wonderful contributors</strong>.

--- a/src/store/launcherReducers.js
+++ b/src/store/launcherReducers.js
@@ -13,16 +13,34 @@ const initial = Immutable.fromJS({
     },
     status: {
         geth: "not ready",
-        connector: "not ready"
+        connector: "not ready",
     }
 });
 
+// TODO: replace me with FS persistent storage along with user settings, eg
+// - window dimensions,
+// - rpc/geth/connector prefs
+function getStoredFirstRun() {
+    if (window.localStorage) {
+        const val = window.localStorage.getItem('emerald_firstRun');
+        if (typeof val !== 'undefined' && JSON.parse(val) === false) {
+            return false;
+        }
+    }
+    return true;
+}
+function setStoredFirstRun() {
+    if (window.localStorage) {
+        window.localStorage.setItem('emerald_firstRun', JSON.stringify(false));
+    }
+}
+
 function onConfig(state, action) {
     if (action.type === 'LAUNCHER/CONFIG') {
-        return state
-            .set('launcherType', action.launcherType)
-            .set('firstRun', action.config.firstRun)
-            .update('chain', (chain) => chain.merge(Immutable.fromJS(action.config.chain || {})))
+        setTimeout(setStoredFirstRun, 5000); // HACK
+        return state.set('launcherType', action.launcherType)
+            .set('firstRun', getStoredFirstRun()) // action.firstRu
+            .update('chain', (chain) => chain.merge(Immutable.fromJS(action.config.chain || {})));
     }
     return state;
 }

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -116,7 +116,8 @@ export function waitForServices() {
             unsubscribe();
             log.info("All services are ready to use by Wallet");
             startSync();
-            if (state.screen.get("screen") === 'welcome') {
+            // If not first run, go right to home when ready.
+            if (state.screen.get("screen") === 'welcome' && !state.launcher.get('firstRun')) {
                 store.dispatch(gotoScreen('home'));
             }
         }


### PR DESCRIPTION
rel #159 

refine welcome screen, with regard to footer and beta disclaimer

- uses localStorage to track 'firstRun' so welcome screen only shows once,
with a button to continue to the wallet; ideally we'd store this in the appdata fs along with other user settings but this'll do for starters

![screen shot 2017-06-22 at 15 38 55](https://user-images.githubusercontent.com/10228550/27454858-ffbc656a-5760-11e7-9cd5-bb7f980918e9.png)
![screen shot 2017-06-22 at 15 39 17](https://user-images.githubusercontent.com/10228550/27454859-ffbf22fa-5760-11e7-9ebc-528bc3436893.png)
