### PR TITLE
display empty txs better and send links to browser

### DIFF
--- a/src/components/layout/footer.js
+++ b/src/components/layout/footer.js
@@ -38,11 +38,11 @@ const Render = () => {
             <Col xs={8} style={{color: 'gray', fontWeight: '300'}}>
                 <p style={{marginTop: 0}}>
                 Find an issue? Got a suggestion? <br/>
-                Please let us know on our <a target='_blank' href='https://github.com/ethereumproject/emerald-wallet/issues'>
+                Please let us know on our <a  href='https://github.com/ethereumproject/emerald-wallet/issues'>
                 Github issues page</a>.
                 </p>
                 <p>
-                Made with ❤️&nbsp; by <strong>ETCDEV</strong> and <a target='_blank' href='https://github.com/ethereumproject/emerald-wallet/network/members'>many wonderful contributors</a>.
+                Made with ❤️&nbsp; by <strong>ETCDEV</strong> and <a href='https://github.com/ethereumproject/emerald-wallet/network/members'>many wonderful contributors</a>.
                 </p>
             </Col>
             <Col xs={2} style={align.right}>

--- a/src/components/tx/list.js
+++ b/src/components/tx/list.js
@@ -2,15 +2,19 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow } from 'material-ui/Table';
-import { Card, CardHeader, CardText } from 'material-ui/Card';
+import { Card, CardHeader, CardText, CardActions } from 'material-ui/Card';
+import { Row, Col } from 'react-flexbox-grid/lib/index';
 import FontIcon from 'material-ui/FontIcon';
+import FlatButton from 'material-ui/FlatButton';
 import Avatar from 'material-ui/Avatar';
 import log from 'loglevel';
 import { cardSpace, tables, noShadow, grayBackground } from 'lib/styles';
 import Immutable from 'immutable';
 import Transaction from './transaction';
+import { gotoScreen } from 'store/screenActions';
+import { align } from 'lib/styles';
 
-const Render = ({ transactions }) => {
+const Render = ({ transactions, sendTx, accounts, createAccount }) => {
     const styles = {
         root: {
             display: 'flex',
@@ -49,9 +53,28 @@ const Render = ({ transactions }) => {
                     actAsExpander={false}
                     showExpandableButton={false}
                 />
-                <CardText style={styles.root} expandable={false}>
-                    {table}
-                </CardText>
+                <CardActions style={align.center}>
+                {
+                    (() => {
+                        if (transactions.length) {
+                            return <CardText style={styles.root} expandable={false}>
+                                {table}
+                            </CardText>
+                        }
+                        if (accounts.length && accounts[0] !== Immutable.Map({})) {
+                            return <FlatButton label="Send A Transaction"
+                                icon={<FontIcon className="fa fa-play-circle" />}
+                                style={{backgroundColor: 'limegreen', color: 'white'}}
+                                onClick={sendTx(accounts[0])}/>
+                        }
+                        return <FlatButton label="Create an Account"
+                                icon={<FontIcon className="fa fa-play-circle" />}
+                                style={{backgroundColor: 'limegreen', color: 'white'}}
+                                onClick={createAccount}/>
+                    })()
+                    }
+                }
+                </CardActions>
             </Card>
         </div>
     );
@@ -59,17 +82,28 @@ const Render = ({ transactions }) => {
 
 Render.propTypes = {
     transactions: PropTypes.object.isRequired,
+    accounts: PropTypes.object.isRequired,
+    createAccount: PropTypes.func.isRequired,
+    sendTx: PropTypes.func.isRequired,
 };
 
 const TransactionsList = connect(
     (state, ownProps) => {
         const transactionsAccounts = state.accounts.get('trackedTransactions', Immutable.List());
         const txs = ownProps.transactions || transactionsAccounts;
+        const accounts = state.accounts.get('accounts');
         return {
             transactions: txs.reverse(),
+            accounts,
         };
     },
     (dispatch, ownProps) => ({
+        sendTx: (acc) => {
+            dispatch(gotoScreen('create-tx', acc));
+        },
+        createAccount: () => {
+            dispatch(gotoScreen('generate'));
+        },
     })
 )(Render);
 


### PR DESCRIPTION
rel #168 

While an incremental improvement for the time being, it opens the idea of handling the bigger picture when 0accts and/or 0txs exist... the space might eventually be better spent with some big ol' buttons and informative content about accounts /+ transactions