### PR TITLE
Elaine/client trace

### DIFF
--- a/src/lib/convert.js
+++ b/src/lib/convert.js
@@ -133,7 +133,8 @@ export function estimateGasFromTrace(dataObj, trace) {
         if (stateDiff) {
             const fromState = new BigNumber(stateDiff.from);
             const toState = new BigNumber(stateDiff.to);
-            estGas = fromState.sub(toState).sub(value);
+            estGas = fromState.sub(toState);
+            estGas = (dataObj.from.toLowerCase() === dataObj.to.toLowerCase()) ? estGas : estGas.sub(value);
             log.debug('Start balance: ' + mweiToWei(fromState).toString(10));
             log.debug('End balance: ' + mweiToWei(toState).toString(10));
             log.debug(fromState.sub(toState).toString(10))

--- a/src/store/launcherReducers.js
+++ b/src/store/launcherReducers.js
@@ -6,6 +6,7 @@ const initial = Immutable.fromJS({
     launcherType: 'web',
     terms: 'none',
     chain: {
+        client: null,
         rpc: null,
         // rpc: "remote", url: "http://api.gastracker.io/web3"
     },

--- a/src/store/tokenActions.js
+++ b/src/store/tokenActions.js
@@ -172,7 +172,11 @@ export function transferTokenTransaction(accountId, password, to, gas, gasPrice,
 }
 
 export function traceCall(accountId, to, gas, gasPrice, value, data) {
-    return () => {
+    return (dispatch, getState) => {
+        const gethClient = getState().launcher.get('chain').get('client')
+            .substring(0, 4) === 'geth';
+        const call = gethClient ? 'eth_traceCall' : 'trace_call';
+        const traceParam = gethClient ? 'latest' : ['trace'];
         const params = [{
             from: accountId,
             to,
@@ -180,8 +184,8 @@ export function traceCall(accountId, to, gas, gasPrice, value, data) {
             gasPrice,
             value,
             data,
-        }, 'latest'];
-        return rpc.call('eth_traceCall', params);
+        }, traceParam];
+        return rpc.call(call, params);
     };
 }
 

--- a/src/store/tokenActions.js
+++ b/src/store/tokenActions.js
@@ -176,7 +176,6 @@ export function traceCall(accountId, to, gas, gasPrice, value, data) {
         const gethClient = getState().launcher.get('chain').get('client')
             .substring(0, 4) === 'geth';
         const call = gethClient ? 'eth_traceCall' : 'trace_call';
-        const traceParam = gethClient ? 'latest' : ['trace'];
         const params = [{
             from: accountId,
             to,
@@ -184,7 +183,11 @@ export function traceCall(accountId, to, gas, gasPrice, value, data) {
             gasPrice,
             value,
             data,
-        }, traceParam];
+        }];
+        if (!gethClient) {
+            params.push(['trace', 'stateDiff']);
+        }
+        params.push('latest');
         return rpc.call(call, params);
     };
 }


### PR DESCRIPTION
Checks for client version, differentiate `traceCall` based on geth vs parity.
Addresses #213, #235 
See also: https://github.com/ethereumproject/emerald-rs/issues/97