### PR TITLE
write cargo path update to .profile and only install if needed

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -4,39 +4,55 @@ EMERALD_CLI_VER=0.19.0
 
 set -e
 
-# Get cargo.
-if command -v cargo 2>/dev/null; then
-    # Have cargo already.
-    echo "Cargo already installed."
-else
-    # No cargo yet.
-    echo "Rusting up (non-interactively; accepting defaults)..."
-    curl https://sh.rustup.rs -sSf | sh -s -- -y
+exit_if_emerald_installed() {
+    echo "Asserting correct version of emerald is installed"
 
-    # Ensure cargo bin is added to PATH, but only if it's not already there.
-    # So developers don't have to worry about a PATH that's miles long
-    # with repetitious cargo pathos.
-    KARGO_PATH=~/.cargo/bin
-    export PATH="${PATH:+"$PATH:"}$KARGO_PATH"
-    echo "Added cargo to path..."
-    echo "PATH -> $PATH"
-fi
+    # emerald command exists in path?
+    if [ -x "$(command -v emerald)" ]; then
 
-# Install and move emerald.
-echo "Installing emerald with cargo..."
-echo "$ cargo install --vers $EMERALD_CLI_VER emerald-cli"
-export RUSTFLAGS="-C target-feature=+crt-static"
-cargo install --vers $EMERALD_CLI_VER emerald-cli -f
+        # emerald is the correct version?
+        if [ "emerald --version" = EMERALD_CLI_VER ]; then
+            echo "emerald $EMERALD_CLI_VER is already installed. Skipping."
+            exit 0
+        fi
+    fi
+}
 
-# Get location of emerald.
-# Should be ~/.cargo/bin/emerald, hopefully.
-emerald_path=$(which emerald)
-echo "Emerald installed to [$emerald_path]"
+ensure_cargo_installed() {
+    if ! [ -x "$(command -v cargo)" ]; then
+        echo "Rusting up (non-interactively; accepting defaults)..."
+        curl https://sh.rustup.rs -sSf | sh -s -- -y
 
-# We'll just put it in the project base dir for now.
-# Note that this assumes CI's $CWD is in the project root.
-echo "Copying emerald from [$emerald_path] to project directory [$(pwd)]..."
-cp "$emerald_path" ./emerald
-chmod +x emerald
+        echo "Adding cargo to path... (and writing to ~/.profile)"
+        echo $PATH:~/.cargo/bin >> ~/.profile
+        source ~/.profile
+        echo "PATH -> $PATH"
+        echo "Cargo installed Successfully."
+    fi
+}
 
-unset emerald_path
+install_emerald() {
+    echo "Installing emerald with cargo..."
+    echo "$ cargo install --vers $EMERALD_CLI_VER emerald-cli"
+    export RUSTFLAGS="-C target-feature=+crt-static"
+    cargo install --vers $EMERALD_CLI_VER emerald-cli -f
+    unset RUSTFLAGS
+
+    # Get location of emerald.
+    # Should be ~/.cargo/bin/emerald, hopefully.
+    emerald_path=$(which emerald)
+    echo "Emerald installed to [$emerald_path]"
+
+    # We'll just put it in the project base dir for now.
+    # Note that this assumes CI's $CWD is in the project root.
+    echo "Copying emerald from [$emerald_path] to project directory [$(pwd)]..."
+    cp "$emerald_path" ./emerald
+    chmod +x emerald
+
+    unset emerald_path
+}
+
+exit_if_emerald_installed
+
+ensure_cargo_installed
+install_emerald


### PR DESCRIPTION
Ideally, rust/cargo wouldn't be a dependency for emerald-wallet. Perhaps using something like [ffi](https://github.com/node-ffi/node-ffi) would be ideal here, but at the very least this PR solves

1. Write new path to `~/.profile` so that cargo remains properly installed across terminal sessions
2. Only install emerald-cli if the version installed to `$PATH` is mismatched with `EMERALD_CLI_VER`
3. Early exit if all conditions are met
4. unset `RUSTFLAGS` after installing (cleanup)
5. using named functions should make it easier to debug / understand whats going on.

worth noting that currently this doesn't work, as 0.17.0 relies on an unpublished version of emerald-rocksdb. However, [another PR](https://github.com/ethereumproject/emerald-wallet/pull/447) bumps the version to 0.19.0 which does work, and so I figure I should leave it as is to avoid conflicts. 