### PR TITLE
problem: Empty string for data prop for eth_estimateGas rpc call 

### DIFF
--- a/src/components/tx/CreateTx/create.js
+++ b/src/components/tx/CreateTx/create.js
@@ -141,7 +141,6 @@ const CreateTx = connect(
           gas: toHex(data.gas),
           to: data.to,
           value: toHex(etherToWei(data.value)),
-          data: '',
         };
       }
 


### PR DESCRIPTION
Empty string for data prop for eth_estimateGas rpc call will return error in case of Parity

solution: Do not provide empty string for data prop for eth_estimateGas call

fixes https://github.com/ethereumproject/emerald-wallet/issues/472