### PR TITLE
No longer need to set path

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -22,11 +22,6 @@ ensure_cargo_installed() {
     if ! [ -x "$(command -v cargo)" ]; then
         echo "Rusting up (non-interactively; accepting defaults)..."
         curl https://sh.rustup.rs -sSf | sh -s -- -y
-
-        echo "Adding cargo to path... (and writing to ~/.profile)"
-        echo $PATH:~/.cargo/bin >> ~/.profile
-        source ~/.profile
-        echo "PATH -> $PATH"
         echo "Cargo installed Successfully."
     fi
 }


### PR DESCRIPTION
The cargo install script sets the path for us, so we don't need this anymore.

Testing notes:
1. Completely uninstall rust/cargo
2. remove ~/.cargo/bin/emerald if it exists still
3. run the `dependencies.sh` script
4. Assert that emerald is avail on your path
5. open a new shell and do 4 again